### PR TITLE
fix: stay in connected view when creating additional wallets

### DIFF
--- a/PrivyExampleApp.xcodeproj/project.pbxproj
+++ b/PrivyExampleApp.xcodeproj/project.pbxproj
@@ -446,7 +446,7 @@
 			repositoryURL = "https://github.com/privy-io/privy-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.0;
+				minimumVersion = 0.4.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PrivyExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PrivyExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/privy-io/privy-ios",
       "state" : {
-        "revision" : "0544d1390573542a653dafc6f08c233a323ead0e",
-        "version" : "0.4.0"
+        "revision" : "88176905d09beaf96898ebc2a181216e139decc5",
+        "version" : "0.4.1"
       }
     },
     {

--- a/PrivyExampleApp/Views/WalletView.swift
+++ b/PrivyExampleApp/Views/WalletView.swift
@@ -46,7 +46,11 @@ struct WalletView: View {
                     case .connecting:
                         ConnectingView()
                     case .creating:
-                        CreatingView()
+                        if privyManager.wallets.isEmpty {
+                            CreatingView()
+                        } else {
+                            connectedView()
+                        }
                     case .recovering:
                         RecoveringView()
                     case .disconnected:


### PR DESCRIPTION
### Description

Previously the app would flash back to the initial wallet creation screen when creating an additional wallet
